### PR TITLE
Pipe Deletion Tweak

### DIFF
--- a/flappy.py
+++ b/flappy.py
@@ -24,7 +24,7 @@ def draw_pipes(pipes):
 			screen.blit(flip_pipe,pipe)
 def remove_pipes(pipes):
 	for pipe in pipes:
-		if pipe.centerx == -600:
+		if pipe.centerx <= -600:
 			pipes.remove(pipe)
 	return pipes
 def check_collision(pipes):


### PR DESCRIPTION
Fixed pipe deletion. Since its possible for the pipe.centerx to get set equal to -600 too quickly, it occasionally stays in the list and slows down performance.